### PR TITLE
Fix errors - extra bracket and missing use Exception

### DIFF
--- a/Sip2.class.php
+++ b/Sip2.class.php
@@ -1211,7 +1211,6 @@ class Sip2
             fclose($this->socket);
         }
     }
-    }
 
 
     /* internal utillity functions */

--- a/Sip2Wrapper.php
+++ b/Sip2Wrapper.php
@@ -1,6 +1,8 @@
 <?php
 namespace tzeumer\Sip2Wrapper;
 
+use Exception;
+
 /**
  * @author nathan@nathanjohnson.info
  */


### PR DESCRIPTION
## Fixes

1. **Sip2.class.php**: Removed duplicate closing brace `}` after the `disconnect()` method (line ~1214) which caused:
   `PHP Parse error: syntax error, unexpected '}', expecting end of file`

2. **Sip2Wrapper.php**: Added missing `use Exception;` statement at the top of the file (required since the class uses `Exception` within a namespace).